### PR TITLE
Shiny requirements

### DIFF
--- a/docs/scripts/acsrq.js
+++ b/docs/scripts/acsrq.js
@@ -4252,11 +4252,26 @@ function setupShinyRequirements() {
         ) {
             const routes = Routes.getRoutesByRegion(regIdx);
             for (let routeIdx = 0; routeIdx <= routes.length; routeIdx++) {
-                replaceRequirements(routes[routeIdx]?.requirements);
+                if (routes[routeIdx]) {
+                    replaceRequirements(routes[routeIdx]?.requirements);
+                    Object.assign(routes[routeIdx], {
+                        isUnlocked: function () {
+                            return (
+                                App.game.statistics.routeKills[this.region][
+                                    this.number
+                                ]() ||
+                                this.requirements.every((requirement) =>
+                                    requirement.isCompleted()
+                                )
+                            );
+                        }
+                    });
+                }
             }
         }
 
         for (let town of Object.values(TownList)) {
+            console.log(town)
             replaceRequirements(town?.requirements);
         }
     } else {

--- a/docs/scripts/acsrq.js
+++ b/docs/scripts/acsrq.js
@@ -4204,7 +4204,7 @@ function setupShinyRequirements() {
                     });
                     Object.assign(requirements[reqIdx], {
                         hint: function () {
-                            return `You are missing ${this.requiredValue - this.getProgress()} shiny in ${Routes.getName(this.route, this.region)}}.`;
+                            return `You are missing ${this.requiredValue - this.getProgress()} shiny in ${Routes.getName(this.route, this.region)}.`;
                         },
                         getProgress: function () {
                             let count = 0;
@@ -4269,6 +4269,33 @@ function setupShinyRequirements() {
                     isUnlocked: function () {
                         return (
                             App.game.statistics.dungeonsCleared[Object.values(dungeonList).indexOf(this.dungeon)]() ||
+                            this.requirements.every(requirement => requirement.isCompleted())
+                        );
+                    }
+                });
+            } else {
+                town.hasGym = -1;
+                town.hasDungeon = -1;
+
+                for (let i = 0; i < town.content.length; i++ ) {
+                    if (town.content[i]?.constructor.name === "Gym")
+                        town.hasGym = i;
+                    if (town.content[i]?.constructor.name === "MoveToDungeon")
+                        town.hasDungeon = i;
+                }
+
+                Object.assign(town, {
+                    isUnlocked: function () {
+                        const alreadyClearGym = (
+                            this.hasGym >= 0 && 
+                            App.game.badgeCase.hasBadge(this.content[this.hasGym]?.badgeReward)
+                        );
+                        const alreadyClearDungeon = (
+                            this.hasDungeon >=0 && 
+                            App.game.statistics.dungeonsCleared[Object.values(dungeonList).indexOf(this.content[this.hasDungeon]?.dungeon)]() 
+                        );
+                        return (
+                            alreadyClearGym || alreadyClearDungeon ||
                             this.requirements.every(requirement => requirement.isCompleted())
                         );
                     }

--- a/docs/scripts/acsrq.js
+++ b/docs/scripts/acsrq.js
@@ -4264,6 +4264,16 @@ function setupShinyRequirements() {
     if (App.game != undefined) {
         for (let town of Object.values(TownList)) {
             replaceRequirements(town?.requirements);
+            if (town.constructor.name === "DungeonTown") {
+                Object.assign(town, {
+                    isUnlocked: function () {
+                        return (
+                            App.game.statistics.dungeonsCleared[Object.values(dungeonList).indexOf(this.dungeon)]() ||
+                            this.requirements.every(requirement => requirement.isCompleted())
+                        );
+                    }
+                });
+            }
         }
 
         for (
@@ -4278,12 +4288,8 @@ function setupShinyRequirements() {
                     Object.assign(routes[routeIdx], {
                         isUnlocked: function () {
                             return (
-                                App.game.statistics.routeKills[this.region][
-                                    this.number
-                                ]() ||
-                                this.requirements.every((requirement) =>
-                                    requirement.isCompleted()
-                                )
+                                App.game.statistics.routeKills[this.region][this.number]() ||
+                                this.requirements.every(requirement => requirement.isCompleted())
                             );
                         }
                     });


### PR DESCRIPTION
Replace `RouteKillRequirement` and `ClearDungeonRequirement` with custom code to check for shiny instead.
In case of shiny becoming available upon meeting some conditions, the routes are protected from locking but some town may relock themselves.
The achievements are not impacted by the custom code.
Custom hints for the requirement tells you how many more shiny you need in a dungeon or a route to unlock the location.